### PR TITLE
Adding string `pattern` regex keyword

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: freddy
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: freddy
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,9 +1,8 @@
 name: freddy
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
-
   # Job to run pre-checks
   pre-checks:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ class User(BaseModel):
 
 sample = freddy.sample(User)
 pprint(sample)
-{'id': 357, 'friends': [308, 613, 549, 35, 869, 460, 630, 961], 'pattern_field': 'rI', 'name': 'yghyjdcsat'}
+{'id': 452, 'signup_ts': '1903-03-12T20:20:00', 'friends': [675, 408], 'pattern_field': 'EUvKs7BIK-Ne', 'name': 'xfphlync'}
 User.validate(sample)
-User(id=565, signup_ts=datetime.datetime(1907, 6, 22, 18, 1), friends=[717, 235, 439, 589], pattern_field='rI', name='John Doe')
+User(id=452, signup_ts=datetime.datetime(1903, 3, 12, 20, 20), friends=[675, 408], pattern_field='EUvKs7BIK-Ne', name='xfphlync')
 ```
 
 ### jsonschema

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Works both for json schema and pydantic models.
 from pprint import pprint
 from datetime import datetime
 from typing import List, Optional
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 import freddy
 
 
@@ -21,6 +21,7 @@ class User(BaseModel):
     name = 'John Doe'
     signup_ts: Optional[datetime] = None
     friends: List[int] = []
+    pattern_field: str = Field(..., regex=r"^[-_a-zA-Z0-9]+$")
 
 
 sample = freddy.sample(User)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Works both for json schema and pydantic models.
 
 ### pydantic
 ```python
+import datetime
 from pprint import pprint
-from datetime import datetime
 from typing import List, Optional
 from pydantic import BaseModel, Field
 import freddy
@@ -19,16 +19,16 @@ import freddy
 class User(BaseModel):
     id: int
     name = 'John Doe'
-    signup_ts: Optional[datetime] = None
+    signup_ts: Optional[datetime.datetime] = None
     friends: List[int] = []
     pattern_field: str = Field(..., regex=r"^[-_a-zA-Z0-9]+$")
 
 
 sample = freddy.sample(User)
 pprint(sample)
-{'friends': [717, 235, 439, 589], 'id': 565, 'signup_ts': '1907-06-22T18:01:00'}
+{'id': 357, 'friends': [308, 613, 549, 35, 869, 460, 630, 961], 'pattern_field': 'rI', 'name': 'yghyjdcsat'}
 User.validate(sample)
-User(id=565, signup_ts=datetime.datetime(1907, 6, 22, 18, 1), friends=[717, 235, 439, 589], name='John Doe')
+User(id=565, signup_ts=datetime.datetime(1907, 6, 22, 18, 1), friends=[717, 235, 439, 589], pattern_field='rI', name='John Doe')
 ```
 
 ### jsonschema

--- a/README.md
+++ b/README.md
@@ -141,10 +141,10 @@ Conforms to JSON Schema Draft 7. The following features are supported:
 - [x] `exclusiveMinimum` and `exclusiveMaximum` in integers and
       numbers.
 - [x] number `multipleOf` keyword
+- [x] string `pattern` regex keyword
 
 - [ ] `required` keyword
 - [ ] `additionalProperties`
-- [ ] string `pattern` regex keyword
 - [ ] all string built-in formats
 - [ ] be able to provide custom basic type factories
 - [ ] multiple types: `{"type": ["string", "array"]}`

--- a/freddy/freddy.py
+++ b/freddy/freddy.py
@@ -1,9 +1,10 @@
 import copy
 import datetime
-import rstr
 import random
 import string
 from typing import Any, Callable, Dict, List, Tuple, Union
+
+import rstr
 
 from .exceptions import InvalidSchema, UnsupportedSchema, UnsupportedType
 from .types import Definitions

--- a/freddy/freddy.py
+++ b/freddy/freddy.py
@@ -1,5 +1,6 @@
 import copy
 import datetime
+import rstr
 import random
 import string
 from typing import Any, Callable, Dict, List, Tuple, Union
@@ -23,7 +24,6 @@ _unsupported_jsonschema_keys = (
     "then",
     "else",
     "multipleOf",
-    "pattern",
     "patternProperties",
     "dependencies",
     "maxProperties",
@@ -116,6 +116,10 @@ def generate(schema: Dict[str, Any], _definitions: Definitions = None) -> Any:
 
 
 def generate_string(schema: Dict[str, Any], string_max: int = 10) -> str:
+    pattern = schema.get("pattern")
+    if pattern is not None:
+        return rstr.xeger(pattern)
+
     supported_formats = ("date-time", "date", "time")
     _format = schema.get("format")
     if _format and _format in supported_formats:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,4 +6,3 @@ max-line-length = 110
 
 [mypy]
 ignore_missing_imports=True
-plugins = pydantic.mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,4 @@ max-line-length = 110
 
 [mypy]
 ignore_missing_imports=True
+plugins = pydantic.mypy

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,6 @@ setup(
     zip_safe=True,
     include_package_data=True,
     packages=find_packages(exclude=["ez_setup"]),
-    install_requires=[],
+    install_requires=["rstr"],
     extras_require={"test": ["pytest", "jsonschema", "pydantic"]},
 )

--- a/tests/test_freddy.py
+++ b/tests/test_freddy.py
@@ -59,7 +59,8 @@ class TestConst(TestBasicType):
 REGEX_TEST_PATTERNS = [
     r"\d{4}-(12|11|10|0?[1-9])-(31|30|[0-2]?\d)T(2[0-3]|1\d|0?[0-9])(:(\d|[0-5]\d)){2}(\.\d{3})?Z",
     r"^(\\([0-9]{3}\\))?[0-9]{3}-[0-9]{4}$",
-    r"^(0|[1-9]\d*)(\.(0|[1-9]\d*)){2}(-(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*)(\.(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*))*)?(\+[-\da-zA-Z]+(\.[-\da-zA-Z-]+)*)?$",
+    r"^(0|[1-9]\d*)(\.(0|[1-9]\d*)){2}(-(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*)"  # line continues below
+    r"(\.(0|[1-9]\d*|\d*[-a-zA-Z][-\da-zA-Z]*))*)?(\+[-\da-zA-Z]+(\.[-\da-zA-Z-]+)*)?$",
     r"^(ju)/(qu)/(ss|qq|fl)(/[\w/-]+)+$",
     r"^(jg)/(du)/qw(/[\w/-]+)+$",
     r"^(jd)/(ru)/s(/[\w/-]+)+$",
@@ -71,7 +72,7 @@ REGEX_TEST_PATTERNS = [
 
 def _check_regex_and_string(generated_string: str, pattern: str) -> None:
     compiled_pattern = re.compile(pattern)
-    match: re.Match = compiled_pattern.search(generated_string)
+    match: Optional[re.Match] = compiled_pattern.search(generated_string)
     assert match is not None
 
 


### PR DESCRIPTION
This PR adds JSONSChema "pattern" support for strings.

- [x] added tests with a few regex options
- [x] extended Pydantic model test with regex fields
- [x] updated documentation/README.md

In the end https://github.com/leapfrogonline/rstr was the better alternative for generating data from a regex

Extras:
- [x] enabled CI in PRs from other users
- [x]  documentation code is now runnable


closes https://github.com/lferran/freddy/issues/8
